### PR TITLE
Add padding and cropping for RIFE interpolation to support for uncommon resolutions

### DIFF
--- a/VideoJaNai/backend/animejanai/core/animejanai_core.py
+++ b/VideoJaNai/backend/animejanai/core/animejanai_core.py
@@ -258,7 +258,7 @@ def run_animejanai(clip, container_fps, chain_conf, backend):
             clip = vs.core.std.Crop(clip, 
                                     left=pad_w//2, right=pad_w - (pad_w//2), 
                                     top=pad_h//2, bottom=pad_h - (pad_h//2))
-            current_logger_steps.append(f"Padded to {target_w + pad_w}x{target_h + pad_h}, applied RIFE v{chain_conf['rife_model']} Interpolation {chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}x, cropped back to {target_w}x{target_h + pad_h};    New Video FPS: {float(container_fps) * chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}")
+            current_logger_steps.append(f"Padded to {target_w + pad_w}x{target_h + pad_h}, applied RIFE v{chain_conf['rife_model']} Interpolation {chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}x, cropped back to {target_w}x{target_h};    New Video FPS: {float(container_fps) * chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}")
         else:
             current_logger_steps.append(f"Applied RIFE v{chain_conf['rife_model']} Interpolation {chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}x;    New Video FPS: {float(container_fps) * chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}")
 

--- a/VideoJaNai/backend/animejanai/core/animejanai_core.py
+++ b/VideoJaNai/backend/animejanai/core/animejanai_core.py
@@ -233,6 +233,16 @@ def run_animejanai(clip, container_fps, chain_conf, backend):
 
     if chain_conf['rife']:
         # TODO rife nvidia or rife other
+        target_w = clip.width
+        target_h = clip.height
+        pad_w = ((target_w + 63) // 64 * 64) - target_w
+        pad_h = ((target_h + 63) // 64 * 64) - target_h
+        if pad_w or pad_h:
+            # We split the padding to keep the image centered
+            clip = vs.core.std.AddBorders(clip, 
+                                          left=pad_w//2, right=pad_w - (pad_w//2), 
+                                          top=pad_h//2, bottom=pad_h - (pad_h//2))
+        
         clip = rife_cuda.rife(
             clip,
             model=chain_conf['rife_model'],
@@ -244,7 +254,13 @@ def run_animejanai(clip, container_fps, chain_conf, backend):
             lt_d2k=True,
             tensorrt=backend.lower() == 'tensorrt'
         )
-        current_logger_steps.append(f"Applied RIFE Interpolation;    New Video FPS: {float(container_fps) * 2:.3f}")
+        if pad_w or pad_h:
+            clip = vs.core.std.Crop(clip, 
+                                    left=pad_w//2, right=pad_w - (pad_w//2), 
+                                    top=pad_h//2, bottom=pad_h - (pad_h//2))
+            current_logger_steps.append(f"Padded to {target_w + pad_w}x{target_h + pad_h}, applied RIFE v{chain_conf['rife_model']} Interpolation {chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}x, cropped back to {target_w}x{target_h + pad_h};    New Video FPS: {float(container_fps) * chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}")
+        else:
+            current_logger_steps.append(f"Applied RIFE v{chain_conf['rife_model']} Interpolation {chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}x;    New Video FPS: {float(container_fps) * chain_conf['rife_factor_numerator'] / chain_conf['rife_factor_denominator']:.3f}")
 
     clip.set_output()
 


### PR DESCRIPTION
As rife requires both dimensions to be dividable by 64 (for example, it will fail for 720x480 (and it's 2x - 1440x960) as 720/1440 can't be split to 64 tiles. To workaround this, we can add padding (black bars) to get appropriate image for rife to work with (1440 will become 1472), and crop these bars afterwards to get our image back. Also added info about used padding and cropping to logger.