### PR TITLE
Finalize 2.0.0: pin aji v0.4.1 + re-runnable deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,5 +80,11 @@ jobs:
         name: ${{ github.event.inputs.release_version }}
         draft: true
         prerelease: false
+        # Re-runnable: update an existing draft in place (replacing same-named assets) instead of
+        # failing because the tag exists. updateOnlyUnreleased guards against clobbering a release
+        # that has already been published.
+        allowUpdates: true
+        updateOnlyUnreleased: true
+        removeArtifacts: true
         artifacts: "VideoJaNai-Setup-${{ github.event.inputs.release_version }}.exe,VideoJaNai-full-package-${{ github.event.inputs.release_version }}.7z.*,manifest.json,publish/packs-v${{ github.event.inputs.release_version }}/component-*.7z,publish/packs-v${{ github.event.inputs.release_version }}/packs.json"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/BuildVideoJaNai/Program.cs
+++ b/BuildVideoJaNai/Program.cs
@@ -25,7 +25,7 @@ using static Downloader;
 // aji_trt.dll must be built against the SAME TensorRT major.minor as the vs-mlrt runtime
 // (v16.x == TensorRT 11.0).
 const string VsMlrtCudaVersion = "v16.test1";              // AmusementClub/vs-mlrt cuda release (TensorRT 11)
-const string AjiVersion        = "v0.4.0";                 // the-database/animejanai-inference (multi-GPU kernels + --pix-fmt + zero-copy 10-bit)
+const string AjiVersion        = "v0.4.1";                 // the-database/animejanai-inference (multi-GPU kernels + --pix-fmt + zero-copy 10-bit + CUDA graphs off by default)
 const string SevenZipVersion   = "2501";                  // 7-zip "extra" standalone console
 const string RifeModelsVersion = "models-rife-fp16-1";    // animejanai-inference rife fp16 release
 const string FfmpegVersion     = "8.1.1";                 // gyan.dev ffmpeg shared build (dev DLLs for aji_encode)


### PR DESCRIPTION
Finalizes the 2.0.0 release inputs on top of PR #60.

- **Pin aji → v0.4.1** (`a623606`): v0.4.1 defaults CUDA graphs off, fixing periodic
  playback stutter on some Ampere GPUs (RTX 3080 / sm86) under TensorRT for negligible
  perf cost. The prior 2.0.0 draft was built with v0.4.0 and lacks this fix.
- **Make `deploy.yml` re-runnable** (`1eaf9c2`): adds `allowUpdates` / `removeArtifacts` /
  `updateOnlyUnreleased` so re-running an existing draft tag updates it in place instead
  of failing.

After merge, re-run `deploy.yml` for 2.0.0 to rebuild the draft with aji v0.4.1.
