### PR TITLE
Revert aji pin to v0.4.0 (offline encode doesn't need the playback-stutter fix)

### DIFF
--- a/BuildVideoJaNai/Program.cs
+++ b/BuildVideoJaNai/Program.cs
@@ -25,7 +25,7 @@ using static Downloader;
 // aji_trt.dll must be built against the SAME TensorRT major.minor as the vs-mlrt runtime
 // (v16.x == TensorRT 11.0).
 const string VsMlrtCudaVersion = "v16.test1";              // AmusementClub/vs-mlrt cuda release (TensorRT 11)
-const string AjiVersion        = "v0.4.1";                 // the-database/animejanai-inference (multi-GPU kernels + --pix-fmt + zero-copy 10-bit + CUDA graphs off by default)
+const string AjiVersion        = "v0.4.0";                 // the-database/animejanai-inference (multi-GPU kernels + --pix-fmt + zero-copy 10-bit). Deliberately NOT v0.4.1: that only defaults CUDA graphs off to fix realtime *playback* stutter, irrelevant to offline batch encode (graphs-on may even be marginally faster across a batch).
 const string SevenZipVersion   = "2501";                  // 7-zip "extra" standalone console
 const string RifeModelsVersion = "models-rife-fp16-1";    // animejanai-inference rife fp16 release
 const string FfmpegVersion     = "8.1.1";                 // gyan.dev ffmpeg shared build (dev DLLs for aji_encode)


### PR DESCRIPTION
Reverts VideoJaNai's aji pin from v0.4.1 back to **v0.4.0**.

v0.4.1's only change is defaulting CUDA graphs off to fix realtime **playback** stutter
on some Ampere GPUs — an mpv/realtime concern. VideoJaNai is an offline batch encoder
(no playback), so the fix is irrelevant here, and graphs-on (v0.4.0) may even be
marginally faster across a long batch. Staying on the already-validated v0.4.0.

aji v0.4.1 remains published on animejanai-inference for the realtime mpv project.

After merge, re-run `deploy.yml` for 2.0.0 to rebuild the draft back to aji v0.4.0.
