### PR TITLE
2.0.0 UX polish: components menu, FPS display, TRT engine settings

### DIFF
--- a/BuildVideoJaNai/Program.cs
+++ b/BuildVideoJaNai/Program.cs
@@ -26,7 +26,7 @@ using static Downloader;
 // (v16.x == TensorRT 11.0).
 const string VsMlrtCudaVersion = "v16.test1";              // AmusementClub/vs-mlrt cuda release (TensorRT 11)
 const string AjiVersion        = "v0.4.0";                 // the-database/animejanai-inference (multi-GPU kernels + --pix-fmt + zero-copy 10-bit). Deliberately NOT v0.4.1: that only defaults CUDA graphs off to fix realtime *playback* stutter, irrelevant to offline batch encode (graphs-on may even be marginally faster across a batch).
-const string SevenZipVersion   = "2501";                  // 7-zip "extra" standalone console
+const string SevenZipVersion   = "2601";                  // 7-zip "extra" standalone console (26.01)
 const string RifeModelsVersion = "models-rife-fp16-1";    // animejanai-inference rife fp16 release
 const string FfmpegVersion     = "8.1.1";                 // gyan.dev ffmpeg shared build (dev DLLs for aji_encode)
 

--- a/VideoJaNai/App.axaml.cs
+++ b/VideoJaNai/App.axaml.cs
@@ -75,6 +75,9 @@ namespace VideoJaNai
             foreach (var wf in state.Workflows)
             {
                 wf.Vm = state;
+                // Migrate engine settings saved by older versions: drop the TensorRT 11 dead flags
+                // (no-ops the native engine strips anyway) so the editor doesn't show stale cruft.
+                wf.TrtEngineSettings = UpscaleWorkflow.NormalizeTrtEngineSettings(wf.TrtEngineSettings);
             }
 
             state.CurrentWorkflow?.Validate();

--- a/VideoJaNai/ViewModels/MainWindowViewModel.cs
+++ b/VideoJaNai/ViewModels/MainWindowViewModel.cs
@@ -1011,11 +1011,19 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
                 var items = new AvaloniaList<ComponentItem>();
                 foreach (var p in (Newtonsoft.Json.Linq.JArray?)root["packs"] ?? new Newtonsoft.Json.Linq.JArray())
                 {
-                    items.Add(new ComponentItem(
-                        (string?)p["name"] ?? "",
-                        (long?)p["bytes"] ?? 0,
-                        (bool?)p["installed"] ?? false,
-                        (bool?)p["recommended"] ?? false));
+                    var name = (string?)p["name"] ?? "";
+                    var installed = (bool?)p["installed"] ?? false;
+                    var recommended = (bool?)p["recommended"] ?? false;
+                    var preselect = (bool?)p["preselect"] ?? false;
+                    // Only surface packs relevant to THIS machine: what it uses (recommended), already
+                    // has (installed, so it can be removed), is offered by default (preselect), or RIFE
+                    // (always a user choice). Per-SM kernel packs for other GPU generations and the
+                    // TensorRT stack on non-NVIDIA boxes are hidden — the updater CLI still lists them all.
+                    if (!installed && !recommended && !preselect && name != "rife")
+                    {
+                        continue;
+                    }
+                    items.Add(new ComponentItem(name, (long?)p["bytes"] ?? 0, installed, recommended, preselect));
                 }
                 Components = items;
             }
@@ -1105,18 +1113,51 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
     // A downloadable runtime component pack, surfaced in the App Settings component manager.
     public class ComponentItem
     {
-        public ComponentItem(string name, long bytes, bool installed, bool recommended)
+        public ComponentItem(string name, long bytes, bool installed, bool recommended, bool preselect)
         {
             Name = name;
             Bytes = bytes;
             Installed = installed;
             Recommended = recommended;
+            Preselect = preselect;
         }
 
         public string Name { get; }
         public long Bytes { get; }
         public bool Installed { get; }
         public bool Recommended { get; }
+        public bool Preselect { get; }
+
+        // User-facing label for the raw pack id (mirrors the AnimeJaNai Manager). Only the pack(s)
+        // relevant to this machine reach the UI, so the SM family shown is the user's own GPU.
+        public string Title => Name switch
+        {
+            "trt-runtime" => "TensorRT runtime",
+            "rife" => "RIFE interpolation models",
+            "trt-ptx" => "TensorRT kernels: other NVIDIA GPUs",
+            _ when Name.StartsWith("trt-sm") => $"TensorRT kernels: {SmFamily(Name[6..])}",
+            _ => Name,
+        };
+
+        public string Description => Name switch
+        {
+            "trt-runtime" => "The fastest upscaling engine, for NVIDIA GPUs. Without it, upscaling falls back to the slower DirectML engine.",
+            "rife" => "Frame interpolation (e.g. 24 → 48 fps). Not needed if you only upscale.",
+            "trt-ptx" => "Fallback kernels for NVIDIA GPUs without a dedicated kernel pack. The first engine build is slower.",
+            _ when Name.StartsWith("trt-sm") => "Engine-builder kernels matched to your GPU generation.",
+            _ => "",
+        };
+
+        // CUDA compute capability (sm) -> consumer GPU family.
+        private static string SmFamily(string sm) => sm switch
+        {
+            "75" => "GeForce RTX 20 series (Turing)",
+            "80" or "86" => "GeForce RTX 30 series (Ampere)",
+            "89" => "GeForce RTX 40 series (Ada)",
+            "90" => "Hopper",
+            "100" or "120" => "GeForce RTX 50 series (Blackwell)",
+            _ => $"sm{sm}",
+        };
 
         public string SizeText => $"{Bytes / 1048576} MB";
         public string StateText => Installed ? "installed" : Recommended ? "recommended" : "available";

--- a/VideoJaNai/ViewModels/MainWindowViewModel.cs
+++ b/VideoJaNai/ViewModels/MainWindowViewModel.cs
@@ -92,6 +92,11 @@ namespace VideoJaNai.ViewModels
             set => this.RaiseAndSetIfChanged(ref _progressPhase, value);
         }
 
+        // Editable-combo suggestions for the TensorRT engine-settings UI (mirrors AnimeJaNaiConfEditor).
+        public string[] CommonResolutions { get; } =
+            ["0x0", "640x360", "640x480", "720x480", "768x576", "960x540", "1024x576", "1280x720", "1440x1080", "1920x1080"];
+        public string[] BuilderOptimizationLevels { get; } = ["0", "1", "2", "3", "4", "5"];
+
         public bool IsInstalled => _updateManagerService.IsInstalled;
 
         private bool _showCheckUpdateButton = true;
@@ -561,7 +566,7 @@ namespace VideoJaNai.ViewModels
             // unchanged value lets libaji use its identical built-in default.
             if (!CurrentWorkflow.DirectMlSelected &&
                 !string.IsNullOrWhiteSpace(CurrentWorkflow.TrtEngineSettings) &&
-                CurrentWorkflow.TrtEngineSettings != UpscaleWorkflow.TrtEngineSettingsStatic)
+                CurrentWorkflow.TrtEngineSettings != UpscaleWorkflow.TrtEngineSettingsDefault)
             {
                 configText.AppendLine($"trt_engine_settings={CurrentWorkflow.TrtEngineSettings}");
             }
@@ -1375,21 +1380,15 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
             }
         }
 
-        // TensorRT engine-build settings (trtexec args). Precision is model-driven (TRT 11
-        // stronglyTyped), so there are no fp16/bf16 options; these control build shapes + builder
-        // options. "Static" = a per-resolution engine (the engine default; fastest inference).
-        // "Dynamic" = one engine spanning a shape range (fewer rebuilds, slightly slower). The
-        // Static string is byte-for-byte libaji's built-in default, so write-minimal can skip it;
-        // libaji also auto-strips any stale weak-typing flags from a custom string.
-        public const string TrtEngineSettingsStatic =
+        // TensorRT engine-build settings (trtexec args) — ported verbatim from AnimeJaNaiConfEditor
+        // so both apps behave identically. The raw string is the single source of truth; Engine Type
+        // / dynamic resolutions / builder optimization level are computed from it and rewrite it.
+        // Precision is model-driven (TRT 11 stronglyTyped), so there are no fp16/bf16 options. This
+        // default is byte-for-byte libaji's built-in default, so write-minimal omits it from the conf.
+        public const string TrtEngineSettingsDefault =
             "--stronglyTyped --optShapes=input:%video_resolution% --inputIOFormats=fp16:chw --outputIOFormats=fp16:chw --builderOptimizationLevel=5 --tacticSources=-CUDNN,-CUBLAS,-CUBLAS_LT --skipInference";
-        public const string TrtEngineSettingsDynamic =
-            "--stronglyTyped --minShapes=input:1x3x8x8 --optShapes=input:1x3x1080x1920 --maxShapes=input:1x3x2160x3840 --inputIOFormats=fp16:chw --outputIOFormats=fp16:chw --builderOptimizationLevel=5 --tacticSources=-CUDNN,-CUBLAS,-CUBLAS_LT --skipInference";
 
-        public bool TrtEngineStaticSelected => TrtEngineSettings == TrtEngineSettingsStatic;
-        public bool TrtEngineDynamicSelected => TrtEngineSettings == TrtEngineSettingsDynamic;
-
-        private string _trtEngineSettings = TrtEngineSettingsStatic;
+        private string _trtEngineSettings = TrtEngineSettingsDefault;
         [DataMember]
         public string TrtEngineSettings
         {
@@ -1397,9 +1396,133 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
             set
             {
                 this.RaiseAndSetIfChanged(ref _trtEngineSettings, value);
-                this.RaisePropertyChanged(nameof(TrtEngineStaticSelected));
-                this.RaisePropertyChanged(nameof(TrtEngineDynamicSelected));
+                this.RaisePropertyChanged(nameof(TrtStaticOnnxSelected));
+                this.RaisePropertyChanged(nameof(TrtStaticSelected));
+                this.RaisePropertyChanged(nameof(TrtDynamicSelected));
+                this.RaisePropertyChanged(nameof(TrtDynamicMinResolution));
+                this.RaisePropertyChanged(nameof(TrtDynamicOptResolution));
+                this.RaisePropertyChanged(nameof(TrtDynamicMaxResolution));
+                this.RaisePropertyChanged(nameof(TrtBuilderOptimizationLevel));
             }
+        }
+
+        public bool TrtDynamicSelected => TrtEngineSettings.Contains("--minShapes=");
+        public bool TrtStaticSelected => TrtEngineSettings.Contains("--optShapes=") && !TrtDynamicSelected;
+        public bool TrtStaticOnnxSelected => !TrtEngineSettings.Contains("--optShapes=") && !TrtDynamicSelected;
+
+        private static string ShapeToResolution(string shapeArg)
+        {
+            var match = Regex.Match(shapeArg, @"input:1x3x(\d+)x(\d+)");
+            if (match.Success)
+                return $"{match.Groups[2].Value}x{match.Groups[1].Value}";
+            return "0x0";
+        }
+
+        private static string ResolutionToShape(string resolution)
+        {
+            var match = Regex.Match(resolution, @"(\d+)x(\d+)");
+            if (match.Success)
+                return $"1x3x{match.Groups[2].Value}x{match.Groups[1].Value}";
+            return "1x3x0x0";
+        }
+
+        private static string? ExtractShapeValue(string settings, string prefix)
+        {
+            var match = Regex.Match(settings, prefix + @"=(\S+)");
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        public string TrtDynamicMinResolution
+        {
+            get
+            {
+                var val = ExtractShapeValue(TrtEngineSettings, "--minShapes");
+                return val != null ? ShapeToResolution(val) : "8x8";
+            }
+            set
+            {
+                var shape = ResolutionToShape(value);
+                TrtEngineSettings = Regex.Replace(TrtEngineSettings, @"--minShapes=\S+", $"--minShapes=input:{shape}");
+            }
+        }
+
+        public string TrtDynamicOptResolution
+        {
+            get
+            {
+                if (!TrtDynamicSelected) return "1920x1080";
+                var val = ExtractShapeValue(TrtEngineSettings, "--optShapes");
+                return val != null ? ShapeToResolution(val) : "1920x1080";
+            }
+            set
+            {
+                var shape = ResolutionToShape(value);
+                if (TrtDynamicSelected)
+                    TrtEngineSettings = Regex.Replace(TrtEngineSettings, @"--optShapes=\S+", $"--optShapes=input:{shape}");
+            }
+        }
+
+        public string TrtDynamicMaxResolution
+        {
+            get
+            {
+                var val = ExtractShapeValue(TrtEngineSettings, "--maxShapes");
+                return val != null ? ShapeToResolution(val) : "1920x1080";
+            }
+            set
+            {
+                var shape = ResolutionToShape(value);
+                TrtEngineSettings = Regex.Replace(TrtEngineSettings, @"--maxShapes=\S+", $"--maxShapes=input:{shape}");
+            }
+        }
+
+        public string TrtBuilderOptimizationLevel
+        {
+            get
+            {
+                var match = Regex.Match(TrtEngineSettings, @"--builderOptimizationLevel=(\d+)");
+                return match.Success ? match.Groups[1].Value : "5";
+            }
+            set
+            {
+                var match = Regex.Match(value ?? "", @"\d+");
+                var level = match.Success ? match.Value : "5";
+                if (Regex.IsMatch(TrtEngineSettings, @"--builderOptimizationLevel=\d+"))
+                    TrtEngineSettings = Regex.Replace(TrtEngineSettings, @"--builderOptimizationLevel=\d+", $"--builderOptimizationLevel={level}");
+                else
+                    TrtEngineSettings = InsertBeforeTactics(TrtEngineSettings, $"--builderOptimizationLevel={level}");
+            }
+        }
+
+        private static string RemoveShapeArgs(string settings)
+        {
+            var result = Regex.Replace(settings, @"\s*--(?:min|opt|max)Shapes=\S+", "");
+            return Regex.Replace(result, @"\s+", " ").Trim();
+        }
+
+        private static string InsertBeforeTactics(string settings, string toInsert)
+        {
+            var idx = settings.IndexOf("--tacticSources", StringComparison.Ordinal);
+            if (idx >= 0)
+                return settings.Insert(idx, toInsert + " ");
+            return settings + " " + toInsert;
+        }
+
+        public void SetTrtStaticOnnx()
+        {
+            TrtEngineSettings = RemoveShapeArgs(TrtEngineSettings);
+        }
+
+        public void SetTrtStatic()
+        {
+            var settings = RemoveShapeArgs(TrtEngineSettings);
+            TrtEngineSettings = InsertBeforeTactics(settings, "--optShapes=input:%video_resolution%");
+        }
+
+        public void SetTrtDynamic()
+        {
+            var settings = RemoveShapeArgs(TrtEngineSettings);
+            TrtEngineSettings = InsertBeforeTactics(settings, "--minShapes=input:1x3x8x8 --optShapes=input:1x3x1080x1920 --maxShapes=input:1x3x1080x1920");
         }
 
         private bool _tensorRtSelected = true;
@@ -1618,9 +1741,6 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
         public void SetOutputPixFmt420P10() { OutputPixFmt = "yuv420p10"; Validate(); }
         public void SetOutputPixFmt444P8() { OutputPixFmt = "yuv444p"; Validate(); }
         public void SetOutputPixFmt444P10() { OutputPixFmt = "yuv444p10"; Validate(); }
-
-        public void SetTrtEngineStatic() => TrtEngineSettings = TrtEngineSettingsStatic;
-        public void SetTrtEngineDynamic() => TrtEngineSettings = TrtEngineSettingsDynamic;
 
         public void SetTensorRtSelected()
         {

--- a/VideoJaNai/ViewModels/MainWindowViewModel.cs
+++ b/VideoJaNai/ViewModels/MainWindowViewModel.cs
@@ -1510,6 +1510,23 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
             return settings + " " + toInsert;
         }
 
+        // Migration for engine settings saved by older versions: strip flags that are dead on
+        // TensorRT 11, preserving everything else (builder level, shapes, --skipInference, custom
+        // flags). Mirrors libaji's sanitize_settings_trt11 (which removes these before building) plus
+        // --stronglyTyped: strongly-typed is the default now (a trtexec no-op), typed IO formats and
+        // the cuDNN/cuBLAS tactic sources are gone, and the weak-typing precision flags were removed.
+        // Purely cosmetic — libaji builds the same engine either way — but keeps the editor clean.
+        public static string NormalizeTrtEngineSettings(string settings)
+        {
+            if (string.IsNullOrWhiteSpace(settings))
+            {
+                return settings;
+            }
+            settings = Regex.Replace(settings, @"\s*--(?:fp16|bf16|int8|best|buildOnly|stronglyTyped)\b", "");
+            settings = Regex.Replace(settings, @"\s*--(?:inputIOFormats|outputIOFormats|tacticSources)=\S+", "");
+            return Regex.Replace(settings, @"\s+", " ").Trim();
+        }
+
         public void SetTrtStaticOnnx()
         {
             TrtEngineSettings = RemoveShapeArgs(TrtEngineSettings);

--- a/VideoJaNai/ViewModels/MainWindowViewModel.cs
+++ b/VideoJaNai/ViewModels/MainWindowViewModel.cs
@@ -1380,13 +1380,15 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
             }
         }
 
-        // TensorRT engine-build settings (trtexec args) — ported verbatim from AnimeJaNaiConfEditor
-        // so both apps behave identically. The raw string is the single source of truth; Engine Type
-        // / dynamic resolutions / builder optimization level are computed from it and rewrite it.
-        // Precision is model-driven (TRT 11 stronglyTyped), so there are no fp16/bf16 options. This
-        // default is byte-for-byte libaji's built-in default, so write-minimal omits it from the conf.
+        // TensorRT engine-build settings (trtexec args). The raw string is the single source of
+        // truth; Engine Type / dynamic resolutions / builder optimization level are computed from it
+        // and rewrite it. Precision is model-driven (TRT 11 strongly-typed by default), so there are
+        // no fp16/bf16 options. Trimmed to only the flags that actually matter on TRT 11:
+        // --stronglyTyped is a deprecated no-op, and libaji's sanitizer strips --inputIOFormats/
+        // --outputIOFormats/--tacticSources anyway. Must stay byte-for-byte equal to libaji's
+        // DEFAULT_TRT_ENGINE_SETTINGS so write-minimal can omit it from the conf.
         public const string TrtEngineSettingsDefault =
-            "--stronglyTyped --optShapes=input:%video_resolution% --inputIOFormats=fp16:chw --outputIOFormats=fp16:chw --builderOptimizationLevel=5 --tacticSources=-CUDNN,-CUBLAS,-CUBLAS_LT --skipInference";
+            "--builderOptimizationLevel=5 --optShapes=input:%video_resolution% --skipInference";
 
         private string _trtEngineSettings = TrtEngineSettingsDefault;
         [DataMember]

--- a/VideoJaNai/ViewModels/MainWindowViewModel.cs
+++ b/VideoJaNai/ViewModels/MainWindowViewModel.cs
@@ -555,9 +555,16 @@ namespace VideoJaNai.ViewModels
             configText.AppendLine("logging=yes");
             configText.AppendLine($"backend={backend}");
 
-            // trt_engine_settings is intentionally omitted: with TensorRT 11 the engine builds
-            // stronglyTyped by default (precision is taken from the ONNX model), so VideoJaNai no
-            // longer exposes a precision/engine-settings picker.
+            // trt_engine_settings (TensorRT only): precision is model-driven (stronglyTyped); these
+            // trtexec args control build shapes + builder options. Written only when changed from the
+            // engine default (Static), matching AnimeJaNaiConfEditor's write-minimal behavior — an
+            // unchanged value lets libaji use its identical built-in default.
+            if (!CurrentWorkflow.DirectMlSelected &&
+                !string.IsNullOrWhiteSpace(CurrentWorkflow.TrtEngineSettings) &&
+                CurrentWorkflow.TrtEngineSettings != UpscaleWorkflow.TrtEngineSettingsStatic)
+            {
+                configText.AppendLine($"trt_engine_settings={CurrentWorkflow.TrtEngineSettings}");
+            }
 
             configText.AppendLine("[slot_1]");
             configText.AppendLine("profile_name=encode");
@@ -1368,12 +1375,43 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
             }
         }
 
+        // TensorRT engine-build settings (trtexec args). Precision is model-driven (TRT 11
+        // stronglyTyped), so there are no fp16/bf16 options; these control build shapes + builder
+        // options. "Static" = a per-resolution engine (the engine default; fastest inference).
+        // "Dynamic" = one engine spanning a shape range (fewer rebuilds, slightly slower). The
+        // Static string is byte-for-byte libaji's built-in default, so write-minimal can skip it;
+        // libaji also auto-strips any stale weak-typing flags from a custom string.
+        public const string TrtEngineSettingsStatic =
+            "--stronglyTyped --optShapes=input:%video_resolution% --inputIOFormats=fp16:chw --outputIOFormats=fp16:chw --builderOptimizationLevel=5 --tacticSources=-CUDNN,-CUBLAS,-CUBLAS_LT --skipInference";
+        public const string TrtEngineSettingsDynamic =
+            "--stronglyTyped --minShapes=input:1x3x8x8 --optShapes=input:1x3x1080x1920 --maxShapes=input:1x3x2160x3840 --inputIOFormats=fp16:chw --outputIOFormats=fp16:chw --builderOptimizationLevel=5 --tacticSources=-CUDNN,-CUBLAS,-CUBLAS_LT --skipInference";
+
+        public bool TrtEngineStaticSelected => TrtEngineSettings == TrtEngineSettingsStatic;
+        public bool TrtEngineDynamicSelected => TrtEngineSettings == TrtEngineSettingsDynamic;
+
+        private string _trtEngineSettings = TrtEngineSettingsStatic;
+        [DataMember]
+        public string TrtEngineSettings
+        {
+            get => _trtEngineSettings;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _trtEngineSettings, value);
+                this.RaisePropertyChanged(nameof(TrtEngineStaticSelected));
+                this.RaisePropertyChanged(nameof(TrtEngineDynamicSelected));
+            }
+        }
+
         private bool _tensorRtSelected = true;
         [DataMember]
         public bool TensorRtSelected
         {
             get => _tensorRtSelected;
-            set => this.RaiseAndSetIfChanged(ref _tensorRtSelected, value);
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _tensorRtSelected, value);
+                this.RaisePropertyChanged(nameof(ShowTrtEngineSettings));
+            }
         }
 
         private bool _directMlSelected = false;
@@ -1514,8 +1552,15 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
         public bool ShowAdvancedSettings
         {
             get => _showAdvancedSettings;
-            set => this.RaiseAndSetIfChanged(ref _showAdvancedSettings, value);
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _showAdvancedSettings, value);
+                this.RaisePropertyChanged(nameof(ShowTrtEngineSettings));
+            }
         }
+
+        // Engine-settings UI is TensorRT-only and lives under Advanced settings.
+        public bool ShowTrtEngineSettings => ShowAdvancedSettings && TensorRtSelected;
 
         public void AddModel()
         {
@@ -1573,6 +1618,9 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
         public void SetOutputPixFmt420P10() { OutputPixFmt = "yuv420p10"; Validate(); }
         public void SetOutputPixFmt444P8() { OutputPixFmt = "yuv444p"; Validate(); }
         public void SetOutputPixFmt444P10() { OutputPixFmt = "yuv444p10"; Validate(); }
+
+        public void SetTrtEngineStatic() => TrtEngineSettings = TrtEngineSettingsStatic;
+        public void SetTrtEngineDynamic() => TrtEngineSettings = TrtEngineSettingsDynamic;
 
         public void SetTensorRtSelected()
         {

--- a/VideoJaNai/ViewModels/MainWindowViewModel.cs
+++ b/VideoJaNai/ViewModels/MainWindowViewModel.cs
@@ -62,6 +62,12 @@ namespace VideoJaNai.ViewModels
         private Process? _runningProcess = null;
         private readonly IETACalculator _etaCalculator = new ETACalculator(10, 5.0);
 
+        // Processing throughput, computed app-side from the PROGRESS frame= counter (aji_encode
+        // emits fps=0). EMA-smoothed since PROGRESS lines arrive in 32-frame bursts.
+        private long _lastFpsFrame = -1;
+        private DateTime _lastFpsTime;
+        private double _smoothedFps;
+
         private double _progressValue;
         [IgnoreDataMember]
         public double ProgressValue
@@ -832,17 +838,38 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
                 ProgressPhase = phaseMatch.Groups[1].Value;
             }
 
+            // FPS: aji_encode always emits fps=0, so derive throughput from how fast the output
+            // frame counter advances. frame=0 lines (build_engine) are skipped, so fps only shows
+            // once real encoding starts.
+            var frameMatch = Regex.Match(line, @"frame=([0-9]+)");
+            if (frameMatch.Success && long.TryParse(frameMatch.Groups[1].Value, NumberStyles.Integer, ENGLISH_CULTURE, out var frame) && frame > 0)
+            {
+                var now = DateTime.UtcNow;
+                if (_lastFpsFrame >= 0 && frame > _lastFpsFrame)
+                {
+                    var seconds = (now - _lastFpsTime).TotalSeconds;
+                    if (seconds > 0)
+                    {
+                        var inst = (frame - _lastFpsFrame) / seconds;
+                        _smoothedFps = _smoothedFps <= 0 ? inst : (0.5 * _smoothedFps) + (0.5 * inst);
+                    }
+                }
+                _lastFpsFrame = frame;
+                _lastFpsTime = now;
+            }
+
             var pctMatch = Regex.Match(line, @"pct=([0-9]+(?:\.[0-9]+)?)");
             if (pctMatch.Success && double.TryParse(pctMatch.Groups[1].Value, NumberStyles.Float, ENGLISH_CULTURE, out var pct))
             {
                 ProgressValue = pct;
 
+                var fpsText = _smoothedFps > 0 ? string.Create(ENGLISH_CULTURE, $" - {_smoothedFps:0.0} fps") : "";
                 if (pct is > 0 and < 100)
                 {
                     _etaCalculator.Update((float)(pct / 100.0));
                     ProgressText = _etaCalculator.ETAIsAvailable
-                        ? string.Create(ENGLISH_CULTURE, $"{pct:0.0}% - ETA {_etaCalculator.ETR:hh\\:mm\\:ss}")
-                        : string.Create(ENGLISH_CULTURE, $"{pct:0.0}%");
+                        ? string.Create(ENGLISH_CULTURE, $"{pct:0.0}%{fpsText} - ETA {_etaCalculator.ETR:hh\\:mm\\:ss}")
+                        : string.Create(ENGLISH_CULTURE, $"{pct:0.0}%{fpsText}");
                 }
                 else
                 {
@@ -856,6 +883,9 @@ chain_1_model_{i + 1}_name={Path.GetFileNameWithoutExtension(CurrentWorkflow.Ups
         private void ResetProgress()
         {
             _etaCalculator.Reset();
+            _lastFpsFrame = -1;
+            _lastFpsTime = default;
+            _smoothedFps = 0;
             ProgressValue = 0;
             ProgressText = string.Empty;
             ProgressPhase = string.Empty;

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -367,6 +367,16 @@
             <TextBlock Foreground="Gray" Width="900" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="40,0,0,0" xml:space="preserve"><Bold>TensorRT</Bold>: <Run Text="{x:Static lang:Resources.UpscalingBackendDescriptionTensorRt}" />
 <Bold>DirectML</Bold>: <Run Text="{x:Static lang:Resources.UpscalingBackendDescriptionDirectMl}" /></TextBlock>
           </StackPanel>
+
+          <StackPanel Orientation="Vertical" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.ShowTrtEngineSettings}">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="TensorRT engine" />
+              <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtEngineStaticSelected}" Content="Static (per-resolution)" Command="{Binding CurrentWorkflow.SetTrtEngineStatic}" />
+              <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtEngineDynamicSelected}" Content="Dynamic (all resolutions)" Command="{Binding CurrentWorkflow.SetTrtEngineDynamic}" />
+              <TextBlock Foreground="Gray" Width="680" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="40,0,0,0" xml:space="preserve"><Bold>Static</Bold>: a separate engine per input resolution (fastest). <Bold>Dynamic</Bold>: one engine for all resolutions (fewer rebuilds, slightly slower). Precision comes from the model. Advanced users can edit the trtexec args below.</TextBlock>
+            </StackPanel>
+            <TextBox Margin="0,8,10,0" Width="900" HorizontalAlignment="Left" TextWrapping="Wrap" AcceptsReturn="False" Text="{Binding CurrentWorkflow.TrtEngineSettings}" />
+          </StackPanel>
             </StackPanel>
           </Border>
 

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -429,7 +429,7 @@
                   <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0">Higher levels (0-5) take longer to build the engine but can produce a faster engine. Default is 5.</TextBlock>
                 </Grid>
 
-                <TextBox Text="{Binding CurrentWorkflow.TrtEngineSettings}" Width="800" HorizontalAlignment="Left" TextWrapping="Wrap" AcceptsReturn="False" MinHeight="70" VerticalContentAlignment="Top" />
+                <TextBox Text="{Binding CurrentWorkflow.TrtEngineSettings}" HorizontalAlignment="Stretch" TextWrapping="Wrap" AcceptsReturn="False" MinHeight="70" VerticalContentAlignment="Top" />
               </StackPanel>
             </Border>
           </StackPanel>

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -9,6 +9,7 @@
         xmlns:lang="clr-namespace:VideoJaNai.Lang"
         mc:Ignorable="d" d:DesignWidth="1920" d:DesignHeight="1080"
         WindowStartupLocation="CenterScreen"
+        MinWidth="900" MinHeight="600"
         x:Class="VideoJaNai.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/logo.ico"
@@ -24,6 +25,21 @@
     </Style>
     <Style Selector="TextBox">
       <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+    <!-- Responsive help text: gray, small, wraps to whatever width its grid column gives it. -->
+    <Style Selector="TextBlock.help">
+      <Setter Property="Foreground" Value="Gray"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="TextWrapping" Value="Wrap"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+      <Setter Property="Margin" Value="20,0,0,0"/>
+    </Style>
+    <Style Selector="SelectableTextBlock.help">
+      <Setter Property="Foreground" Value="Gray"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="TextWrapping" Value="Wrap"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+      <Setter Property="Margin" Value="20,0,0,0"/>
     </Style>
     <Style Selector="Border.border">
 
@@ -148,7 +164,7 @@
         </StackPanel>
       
       
-      <ScrollViewer HorizontalScrollBarVisibility="Auto">
+      <ScrollViewer HorizontalScrollBarVisibility="Disabled">
         <StackPanel Margin="20">
           <Grid>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,20" Grid.Column="0">
@@ -197,12 +213,12 @@
             
               <Border Classes="border">
                 <StackPanel>
-                  <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InputVideoLabel}" />
-                    <TextBox x:Name="InputFileNameTextBox" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.InputFilePath}" IsReadOnly="False" Width="800" DragDrop.AllowDrop="True" />
-                    <Button Content="{x:Static lang:Resources.SelectFileButtonText}" Click="OpenInputFileButtonClick" />
-                    <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.InputVideoDescription}" />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*,Auto" Margin="10,10,0,0">
+                    <TextBlock Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InputVideoLabel}" />
+                    <TextBox Grid.Column="1" x:Name="InputFileNameTextBox" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.InputFilePath}" IsReadOnly="False" HorizontalAlignment="Stretch" DragDrop.AllowDrop="True" />
+                    <Button Grid.Column="2" Content="{x:Static lang:Resources.SelectFileButtonText}" Click="OpenInputFileButtonClick" />
+                  </Grid>
+                  <TextBlock Classes="help" Margin="10,4,10,10" Text="{x:Static lang:Resources.InputVideoDescription}" />
                 </StackPanel>
               </Border>
             
@@ -217,12 +233,12 @@
             
                 <Border Classes="border">
                   <StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                      <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InputFolderLabel}" />
-                      <TextBox x:Name="InputFolderNameTextBox" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.InputFolderPath}" IsReadOnly="False" Width="800" DragDrop.AllowDrop="True" />
-                      <Button Content="{x:Static lang:Resources.SelectFolderButtonText}" Click="OpenInputFolderButtonClick" />
-                      <TextBlock Foreground="Gray" Width="450" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.OutputFolderDescription}" />
-                    </StackPanel>
+                    <Grid ColumnDefinitions="Auto,*,Auto" Margin="10,10,0,0">
+                      <TextBlock Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InputFolderLabel}" />
+                      <TextBox Grid.Column="1" x:Name="InputFolderNameTextBox" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.InputFolderPath}" IsReadOnly="False" HorizontalAlignment="Stretch" DragDrop.AllowDrop="True" />
+                      <Button Grid.Column="2" Content="{x:Static lang:Resources.SelectFolderButtonText}" Click="OpenInputFolderButtonClick" />
+                    </Grid>
+                    <TextBlock Classes="help" Margin="10,4,10,10" Text="{x:Static lang:Resources.OutputFolderDescription}" />
                   </StackPanel>
                 </Border>
             </TabItem>
@@ -232,23 +248,23 @@
 
                 <StackPanel>
 
-                  <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.OutputFolderLabel}" />
-                    <TextBox x:Name="OutputFolderNameTextBox" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.OutputFolderPath}" IsReadOnly="False" Width="800" DragDrop.AllowDrop="True" />
-                    <Button Content="{x:Static lang:Resources.SelectFolderButtonText}" Click="OpenOutputFolderButtonClick" />
-                    <TextBlock Foreground="Gray" Width="450" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.OutputFolderDescription}" />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*,Auto" Margin="10,10,0,0">
+                    <TextBlock Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.OutputFolderLabel}" />
+                    <TextBox Grid.Column="1" x:Name="OutputFolderNameTextBox" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.OutputFolderPath}" IsReadOnly="False" HorizontalAlignment="Stretch" DragDrop.AllowDrop="True" />
+                    <Button Grid.Column="2" Content="{x:Static lang:Resources.SelectFolderButtonText}" Click="OpenOutputFolderButtonClick" />
+                  </Grid>
+                  <TextBlock Classes="help" Margin="10,4,10,10" Text="{x:Static lang:Resources.OutputFolderDescription}" />
 
-                  <StackPanel Orientation="Horizontal" Margin="10,0,0,10">
-                    <TextBlock Margin="0,0,5,0" Text="{x:Static lang:Resources.OutputFilenameLabel}" />
-                    <TextBox Text="{Binding CurrentWorkflow.OutputFilename}" Margin="0,0,5,0" IsReadOnly="False" Width="600" DragDrop.AllowDrop="True" />
-                    <SelectableTextBlock Foreground="Gray" Width="400" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.OutputFilenameDescription}" />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*" Margin="10,0,0,0">
+                    <TextBlock Grid.Column="0" Margin="0,0,5,0" Text="{x:Static lang:Resources.OutputFilenameLabel}" />
+                    <TextBox Grid.Column="1" Text="{Binding CurrentWorkflow.OutputFilename}" Margin="0,0,5,0" IsReadOnly="False" HorizontalAlignment="Stretch" DragDrop.AllowDrop="True" />
+                  </Grid>
+                  <SelectableTextBlock Classes="help" Margin="10,4,10,10" Text="{x:Static lang:Resources.OutputFilenameDescription}" />
 
-                  <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
-                    <CheckBox IsChecked="{Binding CurrentWorkflow.OverwriteExistingVideos}" Content="{x:Static lang:Resources.AllowOverwriteLabel}" />
-                    <TextBlock Width="600" TextWrapping="WrapWithOverflow" Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.AllowOverwriteDescription}" />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,0">
+                    <CheckBox Grid.Column="0" IsChecked="{Binding CurrentWorkflow.OverwriteExistingVideos}" Content="{x:Static lang:Resources.AllowOverwriteLabel}" />
+                    <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.AllowOverwriteDescription}" />
+                  </Grid>
                 
                 </StackPanel>
 
@@ -256,33 +272,37 @@
 
               <Border Classes="border">
                 <StackPanel>
-                  <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FfmpegOutputSettingsLabel}" />
-                    <TextBox Margin="0,0,5,0" Text="{Binding CurrentWorkflow.FfmpegVideoSettings}" IsReadOnly="False" Width="800" />
-                    <TextBlock Width="300" TextWrapping="WrapWithOverflow" Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.FfmpegOutputSettingsDescription}" />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,0">
+                    <TextBlock Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FfmpegOutputSettingsLabel}" />
+                    <TextBox Grid.Column="1" Margin="0,0,5,0" Text="{Binding CurrentWorkflow.FfmpegVideoSettings}" IsReadOnly="False" HorizontalAlignment="Stretch" />
+                  </Grid>
+                  <TextBlock Classes="help" Margin="10,4,10,10" Text="{x:Static lang:Resources.FfmpegOutputSettingsDescription}" />
 
 
-                  <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="10,10,0,10">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FfmpegPresetsLabel}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegHevcNvencSelected}" Content="NVENC HEVC" Command="{Binding CurrentWorkflow.SetFfmpegHevcNvenc}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegX265Selected}" Content="x265 (CPU)" Command="{Binding CurrentWorkflow.SetFfmpegX265}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegX264Selected}" Content="x264 (CPU)" Command="{Binding CurrentWorkflow.SetFfmpegX264}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegLosslessSelected}" Content="Lossless (CPU)" Command="{Binding CurrentWorkflow.SetFfmpegLossless}" />
-                    <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="40,0,0,0" xml:space="preserve"><Run FontWeight="Bold">NVENC HEVC</Run>: <Run Text="{x:Static lang:Resources.FfmpegPresetsDescriptionNvencHevc}" />
+                  <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10">
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                      <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FfmpegPresetsLabel}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegHevcNvencSelected}" Content="NVENC HEVC" Command="{Binding CurrentWorkflow.SetFfmpegHevcNvenc}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegX265Selected}" Content="x265 (CPU)" Command="{Binding CurrentWorkflow.SetFfmpegX265}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegX264Selected}" Content="x264 (CPU)" Command="{Binding CurrentWorkflow.SetFfmpegX264}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.FfmpegLosslessSelected}" Content="Lossless (CPU)" Command="{Binding CurrentWorkflow.SetFfmpegLossless}" />
+                    </StackPanel>
+                    <TextBlock Grid.Column="1" Classes="help" Margin="40,0,0,0" xml:space="preserve"><Run FontWeight="Bold">NVENC HEVC</Run>: <Run Text="{x:Static lang:Resources.FfmpegPresetsDescriptionNvencHevc}" />
 <hypertext:Hyperlink FontWeight="Bold" Url="https://ffmpeg.org/ffmpeg-codecs.html#libx265" Text="x265 (CPU)" />: <Run Text="{x:Static lang:Resources.FfmpegPresetsDescriptionX265}" />
 <hypertext:Hyperlink FontWeight="Bold" Url="https://ffmpeg.org/ffmpeg-codecs.html#libx264_002c-libx264rgb" Text="x264 (CPU)" />: <Run Text="{x:Static lang:Resources.FfmpegPresetsDescriptionX264}" />
 <Run FontWeight="Bold">Lossless (CPU)</Run>: <Run Text="{x:Static lang:Resources.FfmpegPresetsDescriptionLossless}" /></TextBlock>
-                  </StackPanel>
+                  </Grid>
 
-                  <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="10,10,0,10">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Output format" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt420P8Selected}" Content="8-bit 4:2:0" Command="{Binding CurrentWorkflow.SetOutputPixFmt420P8}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt420P10Selected}" Content="10-bit 4:2:0" Command="{Binding CurrentWorkflow.SetOutputPixFmt420P10}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt444P8Selected}" Content="8-bit 4:4:4" Command="{Binding CurrentWorkflow.SetOutputPixFmt444P8}" />
-                    <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt444P10Selected}" Content="10-bit 4:4:4" Command="{Binding CurrentWorkflow.SetOutputPixFmt444P10}" />
-                    <TextBlock Width="320" TextWrapping="WrapWithOverflow" Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="40,0,0,0" Text="10-bit reduces banding (default, matches the old pipeline). 4:4:4 preserves full chroma but needs a CPU encoder (x265/x264/Lossless) and produces larger files." />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10">
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                      <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Output format" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt420P8Selected}" Content="8-bit 4:2:0" Command="{Binding CurrentWorkflow.SetOutputPixFmt420P8}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt420P10Selected}" Content="10-bit 4:2:0" Command="{Binding CurrentWorkflow.SetOutputPixFmt420P10}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt444P8Selected}" Content="8-bit 4:4:4" Command="{Binding CurrentWorkflow.SetOutputPixFmt444P8}" />
+                      <ToggleButton IsChecked="{Binding CurrentWorkflow.OutputPixFmt444P10Selected}" Content="10-bit 4:4:4" Command="{Binding CurrentWorkflow.SetOutputPixFmt444P10}" />
+                    </StackPanel>
+                    <TextBlock Grid.Column="1" Classes="help" Margin="40,0,0,0" Text="10-bit reduces banding (default, matches the old pipeline). 4:4:4 preserves full chroma but needs a CPU encoder (x265/x264/Lossless) and produces larger files." />
+                  </Grid>
                 </StackPanel>
               </Border>
 
@@ -305,24 +325,27 @@
                   <Grid>
                     <StackPanel Grid.Column="0">
                       <TextBlock FontWeight="Bold" Margin="10,10,0,10" Text="{Binding ModelHeader}" />
-                      <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding $parent[ItemsControl].((vm:MainWindowViewModel)DataContext).CurrentWorkflow.ShowAdvancedSettings}}">
-                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.ResizeHeightBeforeUpscaleLabel}" />
-                        <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding ResizeHeightBeforeUpscale}" Minimum="0" AllowSpin="False" ShowButtonSpinner="False" />
-                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">px</TextBlock>
-                        <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.ResizeHeightBeforeUpscaleDescription}" />
-                      </StackPanel>
-                      <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding $parent[ItemsControl].((vm:MainWindowViewModel)DataContext).CurrentWorkflow.ShowAdvancedSettings}">
-                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.ResizeFactorBeforeUpscaleLabel}" />
-                        <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding ResizeFactorBeforeUpscale}" Minimum="0" AllowSpin="False" ShowButtonSpinner="False" IsEnabled="{Binding EnableResizeFactor}" />
-                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">%</TextBlock>
-                        <TextBlock Foreground="Gray" Width="800" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.ResizeFactorBeforeUpscaleDescription}" />
-                      </StackPanel>
-                      <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.OnnxModelPathLabel}" />
-                        <TextBox Margin="0,0,5,0" Text="{Binding OnnxModelPath}" IsReadOnly="False" Width="800" />
-                        <Button Content="{x:Static lang:Resources.SelectFileButtonText}" Click="OpenOnnxFileButtonClick" />
-                        <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" />
-                      </StackPanel>
+                      <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding $parent[ItemsControl].((vm:MainWindowViewModel)DataContext).CurrentWorkflow.ShowAdvancedSettings}">
+                        <StackPanel Grid.Column="0" Orientation="Horizontal">
+                          <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.ResizeHeightBeforeUpscaleLabel}" />
+                          <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding ResizeHeightBeforeUpscale}" Minimum="0" AllowSpin="False" ShowButtonSpinner="False" />
+                          <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">px</TextBlock>
+                        </StackPanel>
+                        <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.ResizeHeightBeforeUpscaleDescription}" />
+                      </Grid>
+                      <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding $parent[ItemsControl].((vm:MainWindowViewModel)DataContext).CurrentWorkflow.ShowAdvancedSettings}">
+                        <StackPanel Grid.Column="0" Orientation="Horizontal">
+                          <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.ResizeFactorBeforeUpscaleLabel}" />
+                          <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding ResizeFactorBeforeUpscale}" Minimum="0" AllowSpin="False" ShowButtonSpinner="False" IsEnabled="{Binding EnableResizeFactor}" />
+                          <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">%</TextBlock>
+                        </StackPanel>
+                        <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.ResizeFactorBeforeUpscaleDescription}" />
+                      </Grid>
+                      <Grid ColumnDefinitions="Auto,*,Auto" Margin="10,10,0,10">
+                        <TextBlock Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.OnnxModelPathLabel}" />
+                        <TextBox Grid.Column="1" Margin="0,0,5,0" Text="{Binding OnnxModelPath}" IsReadOnly="False" HorizontalAlignment="Stretch" />
+                        <Button Grid.Column="2" Content="{x:Static lang:Resources.SelectFileButtonText}" Click="OpenOnnxFileButtonClick" />
+                      </Grid>
                     </StackPanel>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="10,10,0,10" HorizontalAlignment="Right" VerticalAlignment="Top">
@@ -346,27 +369,33 @@
             </StackPanel>
           </Button>
 
-          <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-            <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FinalResizeHeightLabel}" />
-            <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding CurrentWorkflow.FinalResizeHeight}" Minimum="0" AllowSpin="False" ShowButtonSpinner="False" Classes="clearButton"  />
-            <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">px</TextBlock>
-            <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.FinalResizeHeightDescription}" />
-          </StackPanel>
+          <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10">
+            <StackPanel Grid.Column="0" Orientation="Horizontal">
+              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FinalResizeHeightLabel}" />
+              <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding CurrentWorkflow.FinalResizeHeight}" Minimum="0" AllowSpin="False" ShowButtonSpinner="False" Classes="clearButton"  />
+              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">px</TextBlock>
+            </StackPanel>
+            <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.FinalResizeHeightDescription}" />
+          </Grid>
 
-          <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.ShowAdvancedSettings}">
-            <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FinalResizeFactorLabel}" />
-            <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding CurrentWorkflow.FinalResizeFactor}" IsEnabled="{Binding CurrentWorkflow.EnableFinalResizeFactor}" />
-            <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">%</TextBlock>
-            <TextBlock Foreground="Gray" Width="800" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.FinalResizeFactorDescription}" />
-          </StackPanel>
+          <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.ShowAdvancedSettings}">
+            <StackPanel Grid.Column="0" Orientation="Horizontal">
+              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.FinalResizeFactorLabel}" />
+              <NumericUpDown Margin="0,0,5,0" VerticalAlignment="Center" Value="{Binding CurrentWorkflow.FinalResizeFactor}" IsEnabled="{Binding CurrentWorkflow.EnableFinalResizeFactor}" />
+              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">%</TextBlock>
+            </StackPanel>
+            <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.FinalResizeFactorDescription}" />
+          </Grid>
 
-          <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="10,10,0,10">
-            <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.UpscalingBackendLabel}" />
-            <ToggleButton IsChecked="{Binding CurrentWorkflow.TensorRtSelected}" Content="TensorRT" Command="{Binding CurrentWorkflow.SetTensorRtSelected}" />
-            <ToggleButton IsChecked="{Binding CurrentWorkflow.DirectMlSelected}" Content="DirectML" Command="{Binding CurrentWorkflow.SetDirectMlSelected}" />
-            <TextBlock Foreground="Gray" Width="900" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="40,0,0,0" xml:space="preserve"><Bold>TensorRT</Bold>: <Run Text="{x:Static lang:Resources.UpscalingBackendDescriptionTensorRt}" />
+          <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10">
+            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.UpscalingBackendLabel}" />
+              <ToggleButton IsChecked="{Binding CurrentWorkflow.TensorRtSelected}" Content="TensorRT" Command="{Binding CurrentWorkflow.SetTensorRtSelected}" />
+              <ToggleButton IsChecked="{Binding CurrentWorkflow.DirectMlSelected}" Content="DirectML" Command="{Binding CurrentWorkflow.SetDirectMlSelected}" />
+            </StackPanel>
+            <TextBlock Grid.Column="1" Classes="help" Margin="40,0,0,0" xml:space="preserve"><Bold>TensorRT</Bold>: <Run Text="{x:Static lang:Resources.UpscalingBackendDescriptionTensorRt}" />
 <Bold>DirectML</Bold>: <Run Text="{x:Static lang:Resources.UpscalingBackendDescriptionDirectMl}" /></TextBlock>
-          </StackPanel>
+          </Grid>
 
           <StackPanel Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.ShowTrtEngineSettings}">
             <TextBlock Margin="0,10,0,5" Text="TensorRT Engine Settings" />
@@ -411,35 +440,41 @@
           <TextBlock Margin="0,40,0,0" FontWeight="Bold" Text="{x:Static lang:Resources.InterpolationSettingsHeader}" />
           <Border Classes="border">
             <StackPanel>
-              <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                <CheckBox IsChecked="{Binding CurrentWorkflow.EnableRife}" Content="{x:Static lang:Resources.EnableInterpolationLabel}" />
-                <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.EnableInterpolationDescription}" />
-              </StackPanel>
+              <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10">
+                <CheckBox Grid.Column="0" IsChecked="{Binding CurrentWorkflow.EnableRife}" Content="{x:Static lang:Resources.EnableInterpolationLabel}" />
+                <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.EnableInterpolationDescription}" />
+              </Grid>
 
-              <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
-                <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InterpolationFactorLabel}" />
-                <NumericUpDown Value="{Binding CurrentWorkflow.RifeFactorNumerator}" Minimum="{Binding CurrentWorkflow.RifeFactorDenominator}" FormatString="0" />
-                <TextBlock xml:space="preserve"> / </TextBlock>
-                <NumericUpDown Value="{Binding CurrentWorkflow.RifeFactorDenominator}" Minimum="1" Maximum="{Binding CurrentWorkflow.RifeFactorNumerator}" FormatString="0" />
-                <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.InterpolationFactorDescription}" />
-              </StackPanel>
-            
-              <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
-                <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InterpolationModelLabel}" />
-                <ComboBox Margin="0,0,5,0" VerticalAlignment="Center" SelectedValue="{Binding CurrentWorkflow.RifeModel}" ItemsSource="{Binding CurrentWorkflow.RifeModelList}" />
-                <TextBlock Foreground="Gray" Width="800" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.InterpolationModelDescription}" />
-              </StackPanel>
+              <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                  <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InterpolationFactorLabel}" />
+                  <NumericUpDown Value="{Binding CurrentWorkflow.RifeFactorNumerator}" Minimum="{Binding CurrentWorkflow.RifeFactorDenominator}" FormatString="0" />
+                  <TextBlock xml:space="preserve"> / </TextBlock>
+                  <NumericUpDown Value="{Binding CurrentWorkflow.RifeFactorDenominator}" Minimum="1" Maximum="{Binding CurrentWorkflow.RifeFactorNumerator}" FormatString="0" />
+                </StackPanel>
+                <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.InterpolationFactorDescription}" />
+              </Grid>
 
-              <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
-                <CheckBox IsChecked="{Binding CurrentWorkflow.RifeEnsemble}" Content="{x:Static lang:Resources.EnsembleLabel}" />
-                <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.EnsembleDescription}" />
-              </StackPanel>
+              <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                  <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.InterpolationModelLabel}" />
+                  <ComboBox Margin="0,0,5,0" VerticalAlignment="Center" SelectedValue="{Binding CurrentWorkflow.RifeModel}" ItemsSource="{Binding CurrentWorkflow.RifeModelList}" />
+                </StackPanel>
+                <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.InterpolationModelDescription}" />
+              </Grid>
 
-              <StackPanel Orientation="Horizontal" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
-                <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.SceneDetectionThresholdLabel}" />
-                <NumericUpDown Value="{Binding CurrentWorkflow.RifeSceneDetectThreshold}" Minimum="0" FormatString="0.000" Maximum="1" Increment="0.05" />
-                <TextBlock Foreground="Gray" Width="900" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.SceneDetectionThresholdDescription}" />
-              </StackPanel>
+              <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
+                <CheckBox Grid.Column="0" IsChecked="{Binding CurrentWorkflow.RifeEnsemble}" Content="{x:Static lang:Resources.EnsembleLabel}" />
+                <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.EnsembleDescription}" />
+              </Grid>
+
+              <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.EnableRife}">
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                  <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="{x:Static lang:Resources.SceneDetectionThresholdLabel}" />
+                  <NumericUpDown Value="{Binding CurrentWorkflow.RifeSceneDetectThreshold}" Minimum="0" FormatString="0.000" Maximum="1" Increment="0.05" />
+                </StackPanel>
+                <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.SceneDetectionThresholdDescription}" />
+              </Grid>
             </StackPanel>
           </Border>
         
@@ -448,7 +483,7 @@
       </DockPanel>
 
       <!-- Settings Overlay -->
-      <ScrollViewer IsVisible="{Binding ShowAppSettings}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,0,30" Grid.Column="1">
+      <ScrollViewer IsVisible="{Binding ShowAppSettings}" HorizontalScrollBarVisibility="Disabled" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0,0,0,30" Grid.Column="1">
         <StackPanel>
         <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="20">
           <DockPanel>
@@ -461,10 +496,10 @@
             <StackPanel>
               <StackPanel IsVisible="{Binding IsInstalled}">
                 <StackPanel>
-                  <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                    <CheckBox IsChecked="{Binding AutoUpdateEnabled}" Content="{x:Static lang:Resources.AutoUpdateLabel}" />
-                    <TextBlock Foreground="Gray" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0" Text="{x:Static lang:Resources.AutoUpdateDescription}" />
-                  </StackPanel>
+                  <Grid ColumnDefinitions="Auto,*" Margin="10,10,0,10">
+                    <CheckBox Grid.Column="0" IsChecked="{Binding AutoUpdateEnabled}" Content="{x:Static lang:Resources.AutoUpdateLabel}" />
+                    <TextBlock Grid.Column="1" Classes="help" Text="{x:Static lang:Resources.AutoUpdateDescription}" />
+                  </Grid>
 
                   <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
                     <TextBlock Text="{x:Static lang:Resources.CurrentVersionLabel}" VerticalAlignment="Center" />

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -491,13 +491,6 @@
 
               <TextBlock Margin="10,10,0,0" Foreground="Gray" FontFamily="Consolas" TextWrapping="WrapWithOverflow" Text="{Binding ComponentStatusText}" />
 
-              <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
-                <Button FontWeight="Bold" Content="Reinstall recommended" Click="ReinstallBackendClick" IsEnabled="{Binding AllowReinstall}" />
-                <TextBlock Foreground="Gray" Width="400" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0">
-                  Re-download the components recommended for your GPU. Try this if upscaling isn't working.
-                </TextBlock>
-              </StackPanel>
-
             </StackPanel>
           </Border>
 
@@ -523,7 +516,7 @@
           <StackPanel Orientation="Horizontal" Margin="0,10,0,0" Width="1200">
             <Button FontWeight="Bold" Background="Red" Content="Reinstall components" Click="ReinstallBackendClick" IsEnabled="{Binding AllowReinstall}" />
             <TextBlock Foreground="Gray" Width="400" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="20,0,0,0">
-              Reinstall the Python environment. Try this if you are having any problems getting upscales to work. This process may take several minutes.
+              Reinstall the recommended components. Try this if you are having any problems getting upscales to work. This process may take several minutes.
             </TextBlock>
           </StackPanel>
         </StackPanel>

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -471,16 +471,19 @@
               <ItemsControl x:Name="ComponentsList" Margin="10,10,0,0" ItemsSource="{Binding Components}">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate x:DataType="vm:ComponentItem">
-                    <StackPanel Orientation="Horizontal" Margin="0,3,0,3">
-                      <TextBlock VerticalAlignment="Center" Width="160" Text="{Binding Name}" />
-                      <TextBlock VerticalAlignment="Center" Width="90" Foreground="Gray" Text="{Binding SizeText}" />
-                      <TextBlock VerticalAlignment="Center" Width="120" Foreground="Gray" Text="{Binding StateText}" />
-                      <Button Content="Install" IsVisible="{Binding CanInstall}"
-                              Command="{Binding #ComponentsList.((vm:MainWindowViewModel)DataContext).InstallComponent}"
-                              CommandParameter="{Binding}" />
-                      <Button Content="Remove" IsVisible="{Binding CanRemove}"
-                              Command="{Binding #ComponentsList.((vm:MainWindowViewModel)DataContext).RemoveComponent}"
-                              CommandParameter="{Binding}" />
+                    <StackPanel Margin="0,4,0,8">
+                      <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Width="320" Text="{Binding Title}" />
+                        <TextBlock VerticalAlignment="Center" Width="80" Foreground="Gray" Text="{Binding SizeText}" />
+                        <TextBlock VerticalAlignment="Center" Width="100" Foreground="Gray" Text="{Binding StateText}" />
+                        <Button Content="Install" IsVisible="{Binding CanInstall}"
+                                Command="{Binding #ComponentsList.((vm:MainWindowViewModel)DataContext).InstallComponent}"
+                                CommandParameter="{Binding}" />
+                        <Button Content="Remove" IsVisible="{Binding CanRemove}"
+                                Command="{Binding #ComponentsList.((vm:MainWindowViewModel)DataContext).RemoveComponent}"
+                                CommandParameter="{Binding}" />
+                      </StackPanel>
+                      <TextBlock Foreground="Gray" FontSize="12" TextWrapping="Wrap" Margin="0,2,10,0" Text="{Binding Description}" />
                     </StackPanel>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -368,14 +368,41 @@
 <Bold>DirectML</Bold>: <Run Text="{x:Static lang:Resources.UpscalingBackendDescriptionDirectMl}" /></TextBlock>
           </StackPanel>
 
-          <StackPanel Orientation="Vertical" Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.ShowTrtEngineSettings}">
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-              <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="TensorRT engine" />
-              <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtEngineStaticSelected}" Content="Static (per-resolution)" Command="{Binding CurrentWorkflow.SetTrtEngineStatic}" />
-              <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtEngineDynamicSelected}" Content="Dynamic (all resolutions)" Command="{Binding CurrentWorkflow.SetTrtEngineDynamic}" />
-              <TextBlock Foreground="Gray" Width="680" TextWrapping="WrapWithOverflow" FontSize="12" VerticalAlignment="Center" Margin="40,0,0,0" xml:space="preserve"><Bold>Static</Bold>: a separate engine per input resolution (fastest). <Bold>Dynamic</Bold>: one engine for all resolutions (fewer rebuilds, slightly slower). Precision comes from the model. Advanced users can edit the trtexec args below.</TextBlock>
-            </StackPanel>
-            <TextBox Margin="0,8,10,0" Width="900" HorizontalAlignment="Left" TextWrapping="Wrap" AcceptsReturn="False" Text="{Binding CurrentWorkflow.TrtEngineSettings}" />
+          <StackPanel Margin="10,10,0,10" IsVisible="{Binding CurrentWorkflow.ShowTrtEngineSettings}">
+            <TextBlock Margin="0,10,0,5" Text="TensorRT Engine Settings" />
+            <Border Classes="border">
+              <StackPanel Margin="10">
+
+                <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,5">
+                  <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">Engine Type</TextBlock>
+                    <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtStaticOnnxSelected}" Content="Static ONNX" Command="{Binding CurrentWorkflow.SetTrtStaticOnnx}" />
+                    <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtStaticSelected}" Content="Static" Command="{Binding CurrentWorkflow.SetTrtStatic}" />
+                    <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtDynamicSelected}" Content="Dynamic" Command="{Binding CurrentWorkflow.SetTrtDynamic}" />
+                  </StackPanel>
+                  <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0" xml:space="preserve">Which input resolutions the engine is built for. <Bold>Static ONNX</Bold> uses the ONNX model's shape. <Bold>Static</Bold> builds for a single resolution and rebuilds when it changes. <Bold>Dynamic</Bold> builds one engine for the resolution range specified below.</TextBlock>
+                </Grid>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,5" IsVisible="{Binding CurrentWorkflow.TrtDynamicSelected}">
+                  <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">Min Resolution</TextBlock>
+                  <ui:FAComboBox IsEditable="True" Width="120" MaxDropDownHeight="600" Text="{Binding CurrentWorkflow.TrtDynamicMinResolution, Mode=TwoWay}" ItemsSource="{Binding CommonResolutions}" />
+                  <TextBlock Margin="10,0,5,0" VerticalAlignment="Center">Opt Resolution</TextBlock>
+                  <ui:FAComboBox IsEditable="True" Width="120" MaxDropDownHeight="600" Text="{Binding CurrentWorkflow.TrtDynamicOptResolution, Mode=TwoWay}" ItemsSource="{Binding CommonResolutions}" />
+                  <TextBlock Margin="10,0,5,0" VerticalAlignment="Center">Max Resolution</TextBlock>
+                  <ui:FAComboBox IsEditable="True" Width="120" MaxDropDownHeight="600" Text="{Binding CurrentWorkflow.TrtDynamicMaxResolution, Mode=TwoWay}" ItemsSource="{Binding CommonResolutions}" />
+                </StackPanel>
+
+                <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,5">
+                  <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center">Builder Optimization Level</TextBlock>
+                    <ui:FAComboBox IsEditable="True" Width="120" MaxDropDownHeight="600" Text="{Binding CurrentWorkflow.TrtBuilderOptimizationLevel, Mode=TwoWay}" ItemsSource="{Binding BuilderOptimizationLevels}" />
+                  </StackPanel>
+                  <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0">Higher levels (0-5) take longer to build the engine but can produce a faster engine. Default is 5.</TextBlock>
+                </Grid>
+
+                <TextBox Text="{Binding CurrentWorkflow.TrtEngineSettings}" MaxWidth="800" HorizontalAlignment="Stretch" />
+              </StackPanel>
+            </Border>
           </StackPanel>
             </StackPanel>
           </Border>

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -380,7 +380,7 @@
                     <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtStaticSelected}" Content="Static" Command="{Binding CurrentWorkflow.SetTrtStatic}" />
                     <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtDynamicSelected}" Content="Dynamic" Command="{Binding CurrentWorkflow.SetTrtDynamic}" />
                   </StackPanel>
-                  <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0" xml:space="preserve">Which input resolutions the engine is built for. <Bold>Static</Bold> (default) tunes the engine to the exact input resolution for the fastest inference; it rebuilds when the resolution changes (a one-time wait per new resolution). <Bold>Dynamic</Bold> builds a single engine spanning the resolution range below, so it never rebuilds — but it runs noticeably slower than a resolution-tuned engine. <Bold>Static ONNX</Bold> uses the model's own declared shape.</TextBlock>
+                  <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0" xml:space="preserve"><Bold>Static</Bold> (default): fastest; rebuilds per resolution. <Bold>Dynamic</Bold>: one engine for all sizes, slower. <Bold>Static ONNX</Bold>: model's shape.</TextBlock>
                 </Grid>
 
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,5" IsVisible="{Binding CurrentWorkflow.TrtDynamicSelected}">

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -400,7 +400,7 @@
                   <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0">Higher levels (0-5) take longer to build the engine but can produce a faster engine. Default is 5.</TextBlock>
                 </Grid>
 
-                <TextBox Text="{Binding CurrentWorkflow.TrtEngineSettings}" MaxWidth="800" HorizontalAlignment="Stretch" />
+                <TextBox Text="{Binding CurrentWorkflow.TrtEngineSettings}" Width="800" HorizontalAlignment="Left" TextWrapping="Wrap" AcceptsReturn="False" MinHeight="70" VerticalContentAlignment="Top" />
               </StackPanel>
             </Border>
           </StackPanel>

--- a/VideoJaNai/Views/MainWindow.axaml
+++ b/VideoJaNai/Views/MainWindow.axaml
@@ -380,7 +380,7 @@
                     <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtStaticSelected}" Content="Static" Command="{Binding CurrentWorkflow.SetTrtStatic}" />
                     <ToggleButton IsChecked="{Binding CurrentWorkflow.TrtDynamicSelected}" Content="Dynamic" Command="{Binding CurrentWorkflow.SetTrtDynamic}" />
                   </StackPanel>
-                  <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0" xml:space="preserve">Which input resolutions the engine is built for. <Bold>Static ONNX</Bold> uses the ONNX model's shape. <Bold>Static</Bold> builds for a single resolution and rebuilds when it changes. <Bold>Dynamic</Bold> builds one engine for the resolution range specified below.</TextBlock>
+                  <TextBlock Grid.Column="1" Foreground="Gray" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center" Margin="20,0,0,0" xml:space="preserve">Which input resolutions the engine is built for. <Bold>Static</Bold> (default) tunes the engine to the exact input resolution for the fastest inference; it rebuilds when the resolution changes (a one-time wait per new resolution). <Bold>Dynamic</Bold> builds a single engine spanning the resolution range below, so it never rebuilds — but it runs noticeably slower than a resolution-tuned engine. <Bold>Static ONNX</Bold> uses the model's own declared shape.</TextBlock>
                 </Grid>
 
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,5" IsVisible="{Binding CurrentWorkflow.TrtDynamicSelected}">


### PR DESCRIPTION
2.0.0 UX polish (from testing the build locally):

- **Components menu — hide irrelevant packs + friendly names.** Show only packs relevant to this
  machine (recommended/installed/preselect, plus RIFE); friendly Title/Description with sm → GPU
  family. Mirrors the AnimeJaNai Manager.
- **Drop the "Reinstall recommended" button** (Python-era holdover; per-component Install/Remove
  covers it). Fix the failed-setup recovery button's stale "Python environment" wording.
- **Show processing FPS** in the progress line (aji_encode emits fps=0, so compute throughput
  app-side from the frame= counter, EMA-smoothed). Comparable to the old ffmpeg `fps=`.
- **Restore customizable TensorRT engine settings** (minus precision, which TRT 11 obsoletes):
  an Advanced-settings editor with Static/Dynamic presets + an editable trtexec-args box, written
  write-minimal to the conf. Matches AnimeJaNaiConfEditor; the migration had over-removed this.

All build clean. Touches only the app (no updater/assembler/aji changes).
